### PR TITLE
Add `MemoryAddr` trait, add `AddrRange` struct, use macro to generate `PhysAddr` and `VirtAddr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wrappers and helper functions for physical and virtual memory addresses.
 ## Examples
 
 ```rust
-use memory_addr::{pa, va, va_range, PhysAddr, VirtAddr};
+use memory_addr::{pa, va, va_range, PhysAddr, VirtAddr, MemoryAddr};
 
 let phys_addr = PhysAddr::from(0x12345678);
 let virt_addr = VirtAddr::from(0x87654321);

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,328 +1,209 @@
-use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::{align_down, align_offset, align_up, is_aligned, PAGE_SIZE_4K};
 
-/// A physical memory address.
+/// A trait for memory addresses.
 ///
-/// It's a wrapper type around an `usize`.
-#[repr(transparent)]
-#[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
-pub struct PhysAddr(usize);
-
-/// A virtual memory address.
-///
-/// It's a wrapper type around an `usize`.
-#[repr(transparent)]
-#[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
-pub struct VirtAddr(usize);
-
-impl PhysAddr {
-    /// Converts an `usize` to a physical address.
-    #[inline]
-    pub const fn from(addr: usize) -> Self {
-        Self(addr)
-    }
-
-    /// Converts the address to an `usize`.
-    #[inline]
-    pub const fn as_usize(self) -> usize {
-        self.0
-    }
+/// Memory addresses here include both physical and virtual addresses, as well as any other
+/// similar types like guest physical addresses in a hypervisor.
+pub trait MemoryAddr:
+    // The address type should be trivially copyable. This implies `Clone`.
+    Copy
+    // The address type should be convertible to and from `usize`.
+    + From<usize>
+    + Into<usize>
+    // The address type should support addition and subtraction with `usize`.
+    + Add<usize>
+    + AddAssign<usize>
+    + Sub<usize>
+    + SubAssign<usize>
+    // The address type should support comparison and equality checks. This implies `PartialEq`,
+    // `Eq`, and `PartialOrd`.
+    + Ord
+    // The address type should support default values.
+    + Default
+{
+    // No methods are required for now. Following are some provided methods.
 
     /// Aligns the address downwards to the given alignment.
-    ///
+    /// 
     /// See the [`align_down`] function for more information.
     #[inline]
-    pub fn align_down<U>(self, align: U) -> Self
+    fn align_down<U>(self, align: U) -> Self
     where
         U: Into<usize>,
     {
-        Self(align_down(self.0, align.into()))
+        Self::from(align_down(self.into(), align.into()))
     }
 
     /// Aligns the address upwards to the given alignment.
-    ///
+    /// 
     /// See the [`align_up`] function for more information.
     #[inline]
-    pub fn align_up<U>(self, align: U) -> Self
+    fn align_up<U>(self, align: U) -> Self
     where
         U: Into<usize>,
     {
-        Self(align_up(self.0, align.into()))
+        Self::from(align_up(self.into(), align.into()))
     }
+
 
     /// Returns the offset of the address within the given alignment.
     ///
     /// See the [`align_offset`] function for more information.
     #[inline]
-    pub fn align_offset<U>(self, align: U) -> usize
+    fn align_offset<U>(self, align: U) -> usize
     where
         U: Into<usize>,
     {
-        align_offset(self.0, align.into())
+        align_offset(self.into(), align.into())
     }
 
     /// Checks whether the address has the demanded alignment.
     ///
     /// See the [`is_aligned`] function for more information.
     #[inline]
-    pub fn is_aligned<U>(self, align: U) -> bool
+    fn is_aligned<U>(self, align: U) -> bool
     where
         U: Into<usize>,
     {
-        is_aligned(self.0, align.into())
+        is_aligned(self.into(), align.into())
     }
 
     /// Aligns the address downwards to 4096 (bytes).
     #[inline]
-    pub const fn align_down_4k(self) -> Self {
-        Self(align_down(self.0, PAGE_SIZE_4K))
+    fn align_down_4k(self) -> Self {
+        Self::from(align_down(self.into(), PAGE_SIZE_4K))
     }
 
     /// Aligns the address upwards to 4096 (bytes).
     #[inline]
-    pub const fn align_up_4k(self) -> Self {
-        Self(align_up(self.0, PAGE_SIZE_4K))
+    fn align_up_4k(self) -> Self {
+        Self::from(align_up(self.into(), PAGE_SIZE_4K))
     }
 
     /// Returns the offset of the address within a 4K-sized page.
     #[inline]
-    pub const fn align_offset_4k(self) -> usize {
-        align_offset(self.0, PAGE_SIZE_4K)
+    fn align_offset_4k(self) -> usize {
+        align_offset(self.into(), PAGE_SIZE_4K)
     }
 
     /// Checks whether the address is 4K-aligned.
     #[inline]
-    pub const fn is_aligned_4k(self) -> bool {
-        is_aligned(self.0, PAGE_SIZE_4K)
+    fn is_aligned_4k(self) -> bool {
+        is_aligned(self.into(), PAGE_SIZE_4K)
     }
 }
 
-impl VirtAddr {
-    /// Converts an `usize` to a virtual address.
-    #[inline]
-    pub const fn from(addr: usize) -> Self {
-        Self(addr)
-    }
-
-    /// Converts the address to an `usize`.
-    #[inline]
-    pub const fn as_usize(self) -> usize {
-        self.0
-    }
-
-    /// Converts the virtual address to a raw pointer.
-    #[inline]
-    pub const fn as_ptr(self) -> *const u8 {
-        self.0 as *const u8
-    }
-
-    /// Converts the virtual address to a mutable raw pointer.
-    #[inline]
-    pub const fn as_mut_ptr(self) -> *mut u8 {
-        self.0 as *mut u8
-    }
-
-    /// Aligns the address downwards to the given alignment.
-    ///
-    /// See the [`align_down`] function for more information.
-    #[inline]
-    pub fn align_down<U>(self, align: U) -> Self
-    where
-        U: Into<usize>,
-    {
-        Self(align_down(self.0, align.into()))
-    }
-
-    /// Aligns the address upwards to the given alignment.
-    ///
-    /// See the [`align_up`] function for more information.
-    #[inline]
-    pub fn align_up<U>(self, align: U) -> Self
-    where
-        U: Into<usize>,
-    {
-        Self(align_up(self.0, align.into()))
-    }
-
-    /// Returns the offset of the address within the given alignment.
-    ///
-    /// See the [`align_offset`] function for more information.
-    #[inline]
-    pub fn align_offset<U>(self, align: U) -> usize
-    where
-        U: Into<usize>,
-    {
-        align_offset(self.0, align.into())
-    }
-
-    /// Checks whether the address has the demanded alignment.
-    ///
-    /// See the [`is_aligned`] function for more information.
-    #[inline]
-    pub fn is_aligned<U>(self, align: U) -> bool
-    where
-        U: Into<usize>,
-    {
-        is_aligned(self.0, align.into())
-    }
-
-    /// Aligns the address downwards to 4096 (bytes).
-    #[inline]
-    pub const fn align_down_4k(self) -> Self {
-        Self(align_down(self.0, PAGE_SIZE_4K))
-    }
-
-    /// Aligns the address upwards to 4096 (bytes).
-    #[inline]
-    pub fn align_up_4k(self) -> Self {
-        Self(align_up(self.0, PAGE_SIZE_4K))
-    }
-
-    /// Returns the offset of the address within a 4K-sized page.
-    #[inline]
-    pub fn align_offset_4k(self) -> usize {
-        align_offset(self.0, PAGE_SIZE_4K)
-    }
-
-    /// Checks whether the address is 4K-aligned.
-    #[inline]
-    pub fn is_aligned_4k(self) -> bool {
-        is_aligned(self.0, PAGE_SIZE_4K)
-    }
+/// Implement the `MemoryAddr` trait for any type that satisfies the required bounds.
+impl<T> MemoryAddr for T where
+    T: Copy
+        + From<usize>
+        + Into<usize>
+        + Add<usize>
+        + AddAssign<usize>
+        + Sub<usize>
+        + SubAssign<usize>
+        + Ord
+        + Default
+{
 }
 
-impl From<usize> for PhysAddr {
-    #[inline]
-    fn from(addr: usize) -> Self {
-        Self(addr)
-    }
+/// Creates a new address type by wrapping an `usize`.
+#[macro_export]
+macro_rules! def_addr_type {
+    ($name:ident, $desc:literal, $display_prefix:literal) => {
+        #[repr(transparent)]
+        #[doc = $desc]
+        #[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
+        pub struct $name(usize);
+
+        impl $name {
+            #[doc = concat!("Converts an `usize` to the address.")]
+            #[inline]
+            pub const fn from_usize(addr: usize) -> Self {
+                Self(addr)
+            }
+
+            #[doc = concat!("Converts the address to an `usize`.")]
+            #[inline]
+            pub const fn as_usize(self) -> usize {
+                self.0
+            }
+        }
+
+        impl From<usize> for $name {
+            #[inline]
+            fn from(addr: usize) -> Self {
+                Self(addr)
+            }
+        }
+
+        impl From<$name> for usize {
+            #[inline]
+            fn from(addr: $name) -> usize {
+                addr.0
+            }
+        }
+
+        impl core::ops::Add<usize> for $name {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: usize) -> Self {
+                Self(self.0 + rhs)
+            }
+        }
+
+        impl core::ops::AddAssign<usize> for $name {
+            #[inline]
+            fn add_assign(&mut self, rhs: usize) {
+                self.0 += rhs;
+            }
+        }
+
+        impl core::ops::Sub<usize> for $name {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: usize) -> Self {
+                Self(self.0 - rhs)
+            }
+        }
+
+        impl core::ops::SubAssign<usize> for $name {
+            #[inline]
+            fn sub_assign(&mut self, rhs: usize) {
+                self.0 -= rhs;
+            }
+        }
+
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_fmt(format_args!(concat!($display_prefix, "{:#x}"), self.0))
+            }
+        }
+
+        impl core::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_fmt(format_args!(concat!($display_prefix, "{:#x}"), self.0))
+            }
+        }
+
+        impl core::fmt::UpperHex for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_fmt(format_args!(concat!($display_prefix, "{:#X}"), self.0))
+            }
+        }
+    };
 }
 
-impl From<usize> for VirtAddr {
-    #[inline]
-    fn from(addr: usize) -> Self {
-        Self(addr)
-    }
-}
-
-impl From<PhysAddr> for usize {
-    #[inline]
-    fn from(addr: PhysAddr) -> usize {
-        addr.0
-    }
-}
-
-impl From<VirtAddr> for usize {
-    #[inline]
-    fn from(addr: VirtAddr) -> usize {
-        addr.0
-    }
-}
-
-impl Add<usize> for PhysAddr {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: usize) -> Self {
-        Self(self.0 + rhs)
-    }
-}
-
-impl AddAssign<usize> for PhysAddr {
-    #[inline]
-    fn add_assign(&mut self, rhs: usize) {
-        *self = *self + rhs;
-    }
-}
-
-impl Sub<usize> for PhysAddr {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: usize) -> Self {
-        Self(self.0 - rhs)
-    }
-}
-
-impl SubAssign<usize> for PhysAddr {
-    #[inline]
-    fn sub_assign(&mut self, rhs: usize) {
-        *self = *self - rhs;
-    }
-}
-
-impl Add<usize> for VirtAddr {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: usize) -> Self {
-        Self(self.0 + rhs)
-    }
-}
-
-impl AddAssign<usize> for VirtAddr {
-    #[inline]
-    fn add_assign(&mut self, rhs: usize) {
-        *self = *self + rhs;
-    }
-}
-
-impl Sub<usize> for VirtAddr {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: usize) -> Self {
-        Self(self.0 - rhs)
-    }
-}
-
-impl SubAssign<usize> for VirtAddr {
-    #[inline]
-    fn sub_assign(&mut self, rhs: usize) {
-        *self = *self - rhs;
-    }
-}
-
-impl fmt::Debug for PhysAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("PA:{:#x}", self.0))
-    }
-}
-
-impl fmt::Debug for VirtAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("VA:{:#x}", self.0))
-    }
-}
-
-impl fmt::LowerHex for PhysAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("PA:{:#x}", self.0))
-    }
-}
-
-impl fmt::UpperHex for PhysAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("PA:{:#X}", self.0))
-    }
-}
-
-impl fmt::LowerHex for VirtAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("VA:{:#x}", self.0))
-    }
-}
-
-impl fmt::UpperHex for VirtAddr {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("VA:{:#X}", self.0))
-    }
-}
+def_addr_type!(PhysAddr, "A physical memory address.", "PA:");
+def_addr_type!(VirtAddr, "A virtual memory address.", "VA:");
 
 /// Alias for [`PhysAddr::from`].
 #[macro_export]
 macro_rules! pa {
     ($addr:expr) => {
-        $crate::PhysAddr::from($addr)
+        $crate::PhysAddr::from_usize($addr)
     };
 }
 
@@ -330,6 +211,6 @@ macro_rules! pa {
 #[macro_export]
 macro_rules! va {
     ($addr:expr) => {
-        $crate::VirtAddr::from($addr)
+        $crate::VirtAddr::from_usize($addr)
     };
 }

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,8 +1,8 @@
 use crate::{align_down, align_offset, align_up, is_aligned, PAGE_SIZE_4K};
 
-/// A trait for memory addresses.
+/// A trait for memory address types.
 ///
-/// Memory addresses here include both physical and virtual addresses, as well as any other
+/// Memory address types here include both physical and virtual addresses, as well as any other
 /// similar types like guest physical addresses in a hypervisor.
 pub trait MemoryAddr:
     // The address type should be trivially copyable. This implies `Clone`.
@@ -19,10 +19,10 @@ impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 
 /// Creates a new address type by wrapping an `usize`.
 #[macro_export]
-macro_rules! def_addr_types {
+macro_rules! def_usize_addr {
     (
         $(#[$meta:meta])*
-        $vis:vis struct $name:ident(usize);
+        $vis:vis type $name:ident;
 
         $($tt:tt)*
     ) => {
@@ -32,13 +32,13 @@ macro_rules! def_addr_types {
         pub struct $name(usize);
 
         impl $name {
-            #[doc = "Converts an `usize` to the address."]
+            #[doc = concat!("Converts an `usize` to an [`", stringify!($name), "`].")]
             #[inline]
             pub const fn from_usize(addr: usize) -> Self {
                 Self(addr)
             }
 
-            #[doc = "Converts the address to an `usize`."]
+            #[doc = concat!("Converts an [`", stringify!($name), "`] to an `usize`.")]
             #[inline]
             pub const fn as_usize(self) -> usize {
                 self.0
@@ -177,17 +177,17 @@ macro_rules! def_addr_types {
             }
         }
 
-        $crate::def_addr_types!($($tt)*);
+        $crate::def_usize_addr!($($tt)*);
     };
     () => {};
 }
 
-def_addr_types! {
+def_usize_addr! {
     #[doc = "A physical memory address."]
-    pub struct PhysAddr(usize);
+    pub type PhysAddr;
 
     #[doc = "A virtual memory address."]
-    pub struct VirtAddr(usize);
+    pub type VirtAddr;
 }
 
 /// Alias for [`PhysAddr::from`].

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -220,11 +220,11 @@ macro_rules! def_usize_addr {
 ///     /// An example address type.
 ///     pub type ExampleAddr;
 /// }
-/// 
+///
 /// def_usize_addr_formatter! {
 ///     ExampleAddr = "EA:{}";
 /// }
-/// 
+///
 /// fn main() {
 ///     assert_eq!(format!("{:?}", PhysAddr::from(0x1abc)), "PA:0x1abc");
 ///     assert_eq!(format!("{:x}", VirtAddr::from(0x1abc)), "VA:0x1abc");

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -19,11 +19,16 @@ impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 
 /// Creates a new address type by wrapping an `usize`.
 #[macro_export]
-macro_rules! def_addr_type {
-    ($name:ident, $desc:literal, $display_prefix:literal) => {
+macro_rules! def_addr_types {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident(usize);
+
+        $($tt:tt)*
+    ) => {
         #[repr(transparent)]
-        #[doc = $desc]
         #[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
+        $(#[$meta])*
         pub struct $name(usize);
 
         impl $name {
@@ -156,26 +161,34 @@ macro_rules! def_addr_type {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!($display_prefix, "{:#x}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "{:#x}"), self.0))
             }
         }
 
         impl core::fmt::LowerHex for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!($display_prefix, "{:#x}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "{:#x}"), self.0))
             }
         }
 
         impl core::fmt::UpperHex for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!($display_prefix, "{:#X}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "{:#X}"), self.0))
             }
         }
+
+        $crate::def_addr_types!($($tt)*);
     };
+    () => {};
 }
 
-def_addr_type!(PhysAddr, "A physical memory address.", "PA:");
-def_addr_type!(VirtAddr, "A virtual memory address.", "VA:");
+def_addr_types! {
+    #[doc = "A physical memory address."]
+    pub struct PhysAddr(usize);
+
+    #[doc = "A virtual memory address."]
+    pub struct VirtAddr(usize);
+}
 
 /// Alias for [`PhysAddr::from`].
 #[macro_export]

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -183,10 +183,10 @@ macro_rules! def_usize_addr {
 }
 
 def_usize_addr! {
-    #[doc = "A physical memory address."]
+    /// A physical memory address.
     pub type PhysAddr;
 
-    #[doc = "A virtual memory address."]
+    /// A virtual memory address.
     pub type VirtAddr;
 }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -184,7 +184,7 @@ macro_rules! def_usize_addr {
 
 /// Creates implementations for the [`core::fmt::Debug`], [`core::fmt::LowerHex`], and
 /// [`core::fmt::UpperHex`] traits for the given address types.
-/// 
+///
 /// For each `$name = $format;`, this macro generates the following items:
 /// - An implementation of [`core::fmt::Debug`] for the address type `$name`, which formats the
 ///   address with `format_args!($format, format_args!("{:#x}", self.0))`,
@@ -192,12 +192,12 @@ macro_rules! def_usize_addr {
 ///   address in the same way as [`core::fmt::Debug`],
 /// - An implementation of [`core::fmt::UpperHex`] for the address type `$name`, which formats the
 ///   address with `format_args!($format, format_args!("{:#X}", self.0))`.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// use memory_addr::{PhysAddr, VirtAddr};
-/// 
+///
 /// assert_eq!(format!("{:?}", PhysAddr::from(0x1abc)), "PA:0x1abc");
 /// assert_eq!(format!("{:x}", VirtAddr::from(0x1abc)), "VA:0x1abc");
 /// assert_eq!(format!("{:X}", PhysAddr::from(0x1abc)), "PA:0x1ABC");

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -161,19 +161,19 @@ macro_rules! def_addr_types {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!(stringify!($name), "{:#x}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "({:#x})"), self.0))
             }
         }
 
         impl core::fmt::LowerHex for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!(stringify!($name), "{:#x}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "({:#x})"), self.0))
             }
         }
 
         impl core::fmt::UpperHex for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                f.write_fmt(format_args!(concat!(stringify!($name), "{:#X}"), self.0))
+                f.write_fmt(format_args!(concat!(stringify!($name), "({:#X})"), self.0))
             }
         }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -46,13 +46,13 @@ impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 ///     pub type ExampleAddr;
 /// }
 ///
-/// fn main() {
-///     const EXAMPLE: ExampleAddr = ExampleAddr::from_usize(0x1234);
-///     const EXAMPLE_USIZE: usize = EXAMPLE.as_usize();
-///     assert_eq!(EXAMPLE_USIZE, 0x1234);
-///     assert_eq!(EXAMPLE.align_down(0x10usize), ExampleAddr::from_usize(0x1230));
-///     assert_eq!(EXAMPLE.align_up_4k(), ExampleAddr::from_usize(0x2000));
-/// }
+/// # fn main() {
+/// const EXAMPLE: ExampleAddr = ExampleAddr::from_usize(0x1234);
+/// const EXAMPLE_USIZE: usize = EXAMPLE.as_usize();
+/// assert_eq!(EXAMPLE_USIZE, 0x1234);
+/// assert_eq!(EXAMPLE.align_down(0x10usize), ExampleAddr::from_usize(0x1230));
+/// assert_eq!(EXAMPLE.align_up_4k(), ExampleAddr::from_usize(0x2000));
+/// # }
 /// ```
 #[macro_export]
 macro_rules! def_usize_addr {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -83,8 +83,6 @@ macro_rules! def_usize_addr {
 
         impl $name {
             /// Aligns the address downwards to the given alignment.
-            ///
-            /// See the [`align_down`] function for more information.
             #[inline]
             pub fn align_down<U>(self, align: U) -> Self
             where
@@ -94,8 +92,6 @@ macro_rules! def_usize_addr {
             }
 
             /// Aligns the address upwards to the given alignment.
-            ///
-            /// See the [`align_up`] function for more information.
             #[inline]
             pub fn align_up<U>(self, align: U) -> Self
             where
@@ -105,8 +101,6 @@ macro_rules! def_usize_addr {
             }
 
             /// Returns the offset of the address within the given alignment.
-            ///
-            /// See the [`align_offset`] function for more information.
             #[inline]
             pub fn align_offset<U>(self, align: U) -> usize
             where
@@ -116,8 +110,6 @@ macro_rules! def_usize_addr {
             }
 
             /// Checks whether the address has the demanded alignment.
-            ///
-            /// See the [`is_aligned`] function for more information.
             #[inline]
             pub fn is_aligned<U>(self, align: U) -> bool
             where

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -182,6 +182,20 @@ macro_rules! def_usize_addr {
     () => {};
 }
 
+impl VirtAddr {
+    /// Converts the virtual address to a raw pointer.
+    #[inline]
+    pub const fn as_ptr(self) -> *const u8 {
+        self.0 as *const u8
+    }
+
+    /// Converts the virtual address to a mutable raw pointer.
+    #[inline]
+    pub const fn as_mut_ptr(self) -> *mut u8 {
+        self.0 as *mut u8
+    }
+}
+
 def_usize_addr! {
     /// A physical memory address.
     pub type PhysAddr;

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,5 +1,3 @@
-use crate::{align_down, align_offset, align_up, is_aligned, PAGE_SIZE_4K};
-
 /// A trait for memory address types.
 ///
 /// Memory address types here include both physical and virtual addresses, as well as any other
@@ -36,6 +34,26 @@ impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 ///   - `align_down`, `align_up`, `align_offset`, `is_aligned`, `align_down_4k`, `align_up_4k`,
 ///     `align_offset_4k`, and `is_aligned_4k`, which correspond to the functions with the same
 ///     names in the crate root.
+///
+/// # Example
+///
+/// ```
+/// use memory_addr::def_usize_addr;
+///
+/// def_usize_addr! {
+///     /// A example address type.
+///     #[derive(Debug)]
+///     pub type ExampleAddr;
+/// }
+///
+/// fn main() {
+///     const EXAMPLE: ExampleAddr = ExampleAddr::from_usize(0x1234);
+///     const EXAMPLE_USIZE: usize = EXAMPLE.as_usize();
+///     assert_eq!(EXAMPLE_USIZE, 0x1234);
+///     assert_eq!(EXAMPLE.align_down(0x10usize), ExampleAddr::from_usize(0x1230));
+///     assert_eq!(EXAMPLE.align_up_4k(), ExampleAddr::from_usize(0x2000));
+/// }
+/// ```
 #[macro_export]
 macro_rules! def_usize_addr {
     (
@@ -72,7 +90,7 @@ macro_rules! def_usize_addr {
             where
                 U: Into<usize>,
             {
-                Self::from_usize(align_down(self.0, align.into()))
+                Self::from_usize($crate::align_down(self.0, align.into()))
             }
 
             /// Aligns the address upwards to the given alignment.
@@ -83,7 +101,7 @@ macro_rules! def_usize_addr {
             where
                 U: Into<usize>,
             {
-                Self::from_usize(align_up(self.0, align.into()))
+                Self::from_usize($crate::align_up(self.0, align.into()))
             }
 
             /// Returns the offset of the address within the given alignment.
@@ -94,7 +112,7 @@ macro_rules! def_usize_addr {
             where
                 U: Into<usize>,
             {
-                align_offset(self.0, align.into())
+                $crate::align_offset(self.0, align.into())
             }
 
             /// Checks whether the address has the demanded alignment.
@@ -105,31 +123,31 @@ macro_rules! def_usize_addr {
             where
                 U: Into<usize>,
             {
-                is_aligned(self.0, align.into())
+                $crate::is_aligned(self.0, align.into())
             }
 
             /// Aligns the address downwards to 4096 (bytes).
             #[inline]
             pub const fn align_down_4k(self) -> Self {
-                Self::from_usize(align_down(self.0, PAGE_SIZE_4K))
+                Self::from_usize($crate::align_down(self.0, $crate::PAGE_SIZE_4K))
             }
 
             /// Aligns the address upwards to 4096 (bytes).
             #[inline]
             pub const fn align_up_4k(self) -> Self {
-                Self::from_usize(align_up(self.0, PAGE_SIZE_4K))
+                Self::from_usize($crate::align_up(self.0, $crate::PAGE_SIZE_4K))
             }
 
             /// Returns the offset of the address within a 4K-sized page.
             #[inline]
             pub const fn align_offset_4k(self) -> usize {
-                align_offset(self.0, PAGE_SIZE_4K)
+                $crate::align_offset(self.0, $crate::PAGE_SIZE_4K)
             }
 
             /// Checks whether the address is 4K-aligned.
             #[inline]
             pub const fn is_aligned_4k(self) -> bool {
-                is_aligned(self.0, PAGE_SIZE_4K)
+                $crate::is_aligned(self.0, $crate::PAGE_SIZE_4K)
             }
         }
 
@@ -196,11 +214,22 @@ macro_rules! def_usize_addr {
 /// # Example
 ///
 /// ```
-/// use memory_addr::{PhysAddr, VirtAddr};
+/// use memory_addr::{PhysAddr, VirtAddr, def_usize_addr, def_usize_addr_formatter};
 ///
-/// assert_eq!(format!("{:?}", PhysAddr::from(0x1abc)), "PA:0x1abc");
-/// assert_eq!(format!("{:x}", VirtAddr::from(0x1abc)), "VA:0x1abc");
-/// assert_eq!(format!("{:X}", PhysAddr::from(0x1abc)), "PA:0x1ABC");
+/// def_usize_addr! {
+///     /// An example address type.
+///     pub type ExampleAddr;
+/// }
+/// 
+/// def_usize_addr_formatter! {
+///     ExampleAddr = "EA:{}";
+/// }
+/// 
+/// fn main() {
+///     assert_eq!(format!("{:?}", PhysAddr::from(0x1abc)), "PA:0x1abc");
+///     assert_eq!(format!("{:x}", VirtAddr::from(0x1abc)), "VA:0x1abc");
+///     assert_eq!(format!("{:X}", ExampleAddr::from(0x1abc)), "EA:0x1ABC");
+/// }
 /// ```
 #[macro_export]
 macro_rules! def_usize_addr_formatter {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -183,7 +183,7 @@ macro_rules! def_usize_addr {
 }
 
 /// Creates implementations for the [`core::fmt::Debug`], [`core::fmt::LowerHex`], and
-/// [`core::fmt::UpperHex`] traits for the given address types.
+/// [`core::fmt::UpperHex`] traits for the given address types defined by the [`def_usize_addr`].
 ///
 /// For each `$name = $format;`, this macro generates the following items:
 /// - An implementation of [`core::fmt::Debug`] for the address type `$name`, which formats the

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,5 +1,3 @@
-use core::ops::{Add, AddAssign, Sub, SubAssign};
-
 use crate::{align_down, align_offset, align_up, is_aligned, PAGE_SIZE_4K};
 
 /// A trait for memory addresses.
@@ -12,102 +10,12 @@ pub trait MemoryAddr:
     // The address type should be convertible to and from `usize`.
     + From<usize>
     + Into<usize>
-    // The address type should support addition and subtraction with `usize`.
-    + Add<usize>
-    + AddAssign<usize>
-    + Sub<usize>
-    + SubAssign<usize>
-    // The address type should support comparison and equality checks. This implies `PartialEq`,
-    // `Eq`, and `PartialOrd`.
-    + Ord
-    // The address type should support default values.
-    + Default
 {
-    // No methods are required for now. Following are some provided methods.
-
-    /// Aligns the address downwards to the given alignment.
-    /// 
-    /// See the [`align_down`] function for more information.
-    #[inline]
-    fn align_down<U>(self, align: U) -> Self
-    where
-        U: Into<usize>,
-    {
-        Self::from(align_down(self.into(), align.into()))
-    }
-
-    /// Aligns the address upwards to the given alignment.
-    /// 
-    /// See the [`align_up`] function for more information.
-    #[inline]
-    fn align_up<U>(self, align: U) -> Self
-    where
-        U: Into<usize>,
-    {
-        Self::from(align_up(self.into(), align.into()))
-    }
-
-
-    /// Returns the offset of the address within the given alignment.
-    ///
-    /// See the [`align_offset`] function for more information.
-    #[inline]
-    fn align_offset<U>(self, align: U) -> usize
-    where
-        U: Into<usize>,
-    {
-        align_offset(self.into(), align.into())
-    }
-
-    /// Checks whether the address has the demanded alignment.
-    ///
-    /// See the [`is_aligned`] function for more information.
-    #[inline]
-    fn is_aligned<U>(self, align: U) -> bool
-    where
-        U: Into<usize>,
-    {
-        is_aligned(self.into(), align.into())
-    }
-
-    /// Aligns the address downwards to 4096 (bytes).
-    #[inline]
-    fn align_down_4k(self) -> Self {
-        Self::from(align_down(self.into(), PAGE_SIZE_4K))
-    }
-
-    /// Aligns the address upwards to 4096 (bytes).
-    #[inline]
-    fn align_up_4k(self) -> Self {
-        Self::from(align_up(self.into(), PAGE_SIZE_4K))
-    }
-
-    /// Returns the offset of the address within a 4K-sized page.
-    #[inline]
-    fn align_offset_4k(self) -> usize {
-        align_offset(self.into(), PAGE_SIZE_4K)
-    }
-
-    /// Checks whether the address is 4K-aligned.
-    #[inline]
-    fn is_aligned_4k(self) -> bool {
-        is_aligned(self.into(), PAGE_SIZE_4K)
-    }
+    // Empty for now.
 }
 
 /// Implement the `MemoryAddr` trait for any type that satisfies the required bounds.
-impl<T> MemoryAddr for T where
-    T: Copy
-        + From<usize>
-        + Into<usize>
-        + Add<usize>
-        + AddAssign<usize>
-        + Sub<usize>
-        + SubAssign<usize>
-        + Ord
-        + Default
-{
-}
+impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 
 /// Creates a new address type by wrapping an `usize`.
 #[macro_export]
@@ -119,16 +27,86 @@ macro_rules! def_addr_type {
         pub struct $name(usize);
 
         impl $name {
-            #[doc = concat!("Converts an `usize` to the address.")]
+            #[doc = "Converts an `usize` to the address."]
             #[inline]
             pub const fn from_usize(addr: usize) -> Self {
                 Self(addr)
             }
 
-            #[doc = concat!("Converts the address to an `usize`.")]
+            #[doc = "Converts the address to an `usize`."]
             #[inline]
             pub const fn as_usize(self) -> usize {
                 self.0
+            }
+        }
+
+        impl $name {
+            /// Aligns the address downwards to the given alignment.
+            ///
+            /// See the [`align_down`] function for more information.
+            #[inline]
+            pub fn align_down<U>(self, align: U) -> Self
+            where
+                U: Into<usize>,
+            {
+                Self::from_usize(align_down(self.0, align.into()))
+            }
+
+            /// Aligns the address upwards to the given alignment.
+            ///
+            /// See the [`align_up`] function for more information.
+            #[inline]
+            pub fn align_up<U>(self, align: U) -> Self
+            where
+                U: Into<usize>,
+            {
+                Self::from_usize(align_up(self.0, align.into()))
+            }
+
+            /// Returns the offset of the address within the given alignment.
+            ///
+            /// See the [`align_offset`] function for more information.
+            #[inline]
+            pub fn align_offset<U>(self, align: U) -> usize
+            where
+                U: Into<usize>,
+            {
+                align_offset(self.0, align.into())
+            }
+
+            /// Checks whether the address has the demanded alignment.
+            ///
+            /// See the [`is_aligned`] function for more information.
+            #[inline]
+            pub fn is_aligned<U>(self, align: U) -> bool
+            where
+                U: Into<usize>,
+            {
+                is_aligned(self.0, align.into())
+            }
+
+            /// Aligns the address downwards to 4096 (bytes).
+            #[inline]
+            pub const fn align_down_4k(self) -> Self {
+                Self::from_usize(align_down(self.0, PAGE_SIZE_4K))
+            }
+
+            /// Aligns the address upwards to 4096 (bytes).
+            #[inline]
+            pub const fn align_up_4k(self) -> Self {
+                Self::from_usize(align_up(self.0, PAGE_SIZE_4K))
+            }
+
+            /// Returns the offset of the address within a 4K-sized page.
+            #[inline]
+            pub const fn align_offset_4k(self) -> usize {
+                align_offset(self.0, PAGE_SIZE_4K)
+            }
+
+            /// Checks whether the address is 4K-aligned.
+            #[inline]
+            pub const fn is_aligned_4k(self) -> bool {
+                is_aligned(self.0, PAGE_SIZE_4K)
             }
         }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -18,6 +18,28 @@ pub trait MemoryAddr:
 impl<T> MemoryAddr for T where T: Copy + From<usize> + Into<usize> {}
 
 /// Creates a new address type by wrapping an `usize`.
+///
+/// For each `$vis type $name;`, this macro generates the following items:
+/// - Definition of the new address type `$name`, which contains a single private unnamed field of
+///   type `usize`.
+/// - Default implementations (i.e. derived implementations) for the following traits:
+///   - `Copy`, `Clone`,
+///   - `Default`,
+///   - `Ord`, `PartialOrd`, `Eq`, and `PartialEq`.
+/// - Implementations for the following traits:
+///   - `From<usize>`, `Into<usize>` (by implementing `From<$name> for usize`),
+///   - `Add<usize>`, `AddAssign<usize>`, `Sub<usize>`, `SubAssign<usize>`, as well as
+///   - `Debug`, `LowerHex`, and `UpperHex`, where
+///     - The implementation of `Debug` uses the format string `"$name({:#x})"` to print the address,
+///     - The implementation of `LowerHex` uses the same format string as `Debug`, and
+///     - The implementation of `UpperHex` uses `"$name({:#X})"`.
+/// - Two `const` methods to convert between the address type and `usize`:
+///   - `from_usize`, which converts an `usize` to the address type, and
+///   - `as_usize`, which converts the address type to an `usize`.
+/// - Methods to align the address, namely:
+///   - `align_down`, `align_up`, `align_offset`, `is_aligned`, `align_down_4k`, `align_up_4k`,
+///     `align_offset_4k`, and `is_aligned_4k`, which correspond to the functions with the same
+///     names in the crate root.
 #[macro_export]
 macro_rules! def_usize_addr {
     (
@@ -204,7 +226,7 @@ def_usize_addr! {
     pub type VirtAddr;
 }
 
-/// Alias for [`PhysAddr::from`].
+/// Alias for [`PhysAddr::from_usize`].
 #[macro_export]
 macro_rules! pa {
     ($addr:expr) => {
@@ -212,7 +234,7 @@ macro_rules! pa {
     };
 }
 
-/// Alias for [`VirtAddr::from`].
+/// Alias for [`VirtAddr::from_usize`].
 #[macro_export]
 macro_rules! va {
     ($addr:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub const fn is_aligned_4k(addr: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{addr::MemoryAddr, va, va_range, VirtAddrRange};
+    use crate::{va, va_range, VirtAddrRange};
 
     #[test]
     fn test_addr() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod range;
 
 pub use self::addr::{MemoryAddr, PhysAddr, VirtAddr};
 pub use self::iter::PageIter;
-pub use self::range::{PhysAddrRange, VirtAddrRange};
+pub use self::range::{AddrRange, PhysAddrRange, VirtAddrRange};
 
 /// The size of a 4K page (4096 bytes).
 pub const PAGE_SIZE_4K: usize = 0x1000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod addr;
 mod iter;
 mod range;
 
-pub use self::addr::{PhysAddr, VirtAddr};
+pub use self::addr::{MemoryAddr, PhysAddr, VirtAddr};
 pub use self::iter::PageIter;
 pub use self::range::{PhysAddrRange, VirtAddrRange};
 
@@ -77,7 +77,7 @@ pub const fn is_aligned_4k(addr: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{va, va_range, VirtAddrRange};
+    use crate::{addr::MemoryAddr, va, va_range, VirtAddrRange};
 
     #[test]
     fn test_addr() {

--- a/src/range.rs
+++ b/src/range.rs
@@ -12,6 +12,16 @@ macro_rules! usize {
 ///
 /// The range is inclusive on the start and exclusive on the end.
 /// It is empty if `start >= end`.
+///
+/// ## Example
+///
+/// ```
+/// use memory_addr::VirtAddrRange;
+///
+/// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+/// assert_eq!(range.start, 0x1000.into());
+/// assert_eq!(range.end, 0x2000.into());
+/// ```
 #[derive(Clone, Copy)]
 pub struct AddrRange<A: MemoryAddr> {
     /// The lower bound of the range (inclusive).

--- a/src/range.rs
+++ b/src/range.rs
@@ -33,7 +33,7 @@ macro_rules! def_range {
             pub const fn from_start_size(start: $addr_type, size: usize) -> Self {
                 Self {
                     start,
-                    end: <$addr_type>::from(usize!(start) + size),
+                    end: <$addr_type>::from_usize(usize!(start) + size),
                 }
             }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -40,9 +40,9 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::VirtAddrRange;
+    /// use memory_addr::{AddrRange, VirtAddr};
     ///
-    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+    /// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
     /// assert_eq!(range.start, 0x1000.into());
     /// assert_eq!(range.end, 0x2000.into());
     /// ```
@@ -56,9 +56,9 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::VirtAddrRange;
+    /// use memory_addr::{AddrRange, VirtAddr};
     ///
-    /// let range = VirtAddrRange::from_start_size(0x1000.into(), 0x1000);
+    /// let range = AddrRange::<VirtAddr>::from_start_size(0x1000.into(), 0x1000);
     /// assert_eq!(range.start, 0x1000.into());
     /// assert_eq!(range.end, 0x2000.into());
     /// ```
@@ -75,11 +75,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
     ///
-    /// assert!(va_range!(0x1000..0x1000).is_empty());
-    /// assert!(va_range!(0x1000..0xfff).is_empty());
-    /// assert!(!va_range!(0x1000..0x2000).is_empty());
+    /// assert!(AddrRange::<VirtAddr>::from(0x1000..0x1000).is_empty());
+    /// assert!(AddrRange::<VirtAddr>::from(0x1000..0xfff).is_empty());
+    /// assert!(!AddrRange::<VirtAddr>::from(0x1000..0x2000).is_empty());
     /// ```
     #[inline]
     pub fn is_empty(self) -> bool {
@@ -91,10 +91,10 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
     ///
-    /// let range = va_range!(0x1000..0x2000);
-    /// assert_eq!(range.size(), 0x1000);
+    /// assert_eq!(AddrRange::<VirtAddr>::from(0x1000..0x1000).size(), 0);
+    /// assert_eq!(AddrRange::<VirtAddr>::from(0x1000..0x2000).size(), 0x1000);
     /// ```
     #[inline]
     pub fn size(self) -> usize {
@@ -106,9 +106,9 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
     ///
-    /// let range = va_range!(0x1000..0x2000);
+    /// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
     /// assert!(!range.contains(0xfff.into()));
     /// assert!(range.contains(0x1000.into()));
     /// assert!(range.contains(0x1fff.into()));
@@ -124,15 +124,16 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
+    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
     ///
-    /// let range = va_range!(0x1000..0x2000);
-    /// assert!(!range.contains_range(va_range!(0x0..0xfff)));
-    /// assert!(!range.contains_range(va_range!(0xfff..0x1fff)));
-    /// assert!(range.contains_range(va_range!(0x1001..0x1fff)));
-    /// assert!(range.contains_range(va_range!(0x1000..0x2000)));
-    /// assert!(!range.contains_range(va_range!(0x1001..0x2001)));
-    /// assert!(!range.contains_range(va_range!(0x2001..0x3001)));
+    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+    /// assert!(!range.contains_range(VirtAddrRange::from(0x0..0xfff)));
+    /// assert!(!range.contains_range(VirtAddrRange::from(0xfff..0x1fff)));
+    /// assert!(range.contains_range(VirtAddrRange::from(0x1001..0x1fff)));
+    /// assert!(range.contains_range(VirtAddrRange::from(0x1000..0x2000)));
+    /// assert!(!range.contains_range(VirtAddrRange::from(0x1001..0x2001)));
+    /// assert!(!range.contains_range(VirtAddrRange::from(0x2001..0x3001)));
     /// ```
     #[inline]
     pub fn contains_range(self, other: Self) -> bool {
@@ -144,13 +145,14 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
+    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
     ///
-    /// let range = va_range!(0x1000..0x2000);
-    /// assert!(!range.contained_in(va_range!(0xfff..0x1fff)));
-    /// assert!(!range.contained_in(va_range!(0x1001..0x2001)));
-    /// assert!(range.contained_in(va_range!(0xfff..0x2001)));
-    /// assert!(range.contained_in(va_range!(0x1000..0x2000)));
+    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+    /// assert!(!range.contained_in(VirtAddrRange::from(0xfff..0x1fff)));
+    /// assert!(!range.contained_in(VirtAddrRange::from(0x1001..0x2001)));
+    /// assert!(range.contained_in(VirtAddrRange::from(0xfff..0x2001)));
+    /// assert!(range.contained_in(VirtAddrRange::from(0x1000..0x2000)));
     /// ```
     #[inline]
     pub fn contained_in(self, other: Self) -> bool {
@@ -162,15 +164,16 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::va_range;
+    /// use memory_addr::{AddrRange, VirtAddr};
+    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
     ///
-    /// let range = va_range!(0x1000..0x2000);
-    /// assert!(!range.overlaps(va_range!(0xfff..0xfff)));
-    /// assert!(!range.overlaps(va_range!(0x2000..0x2000)));
-    /// assert!(!range.overlaps(va_range!(0xfff..0x1000)));
-    /// assert!(range.overlaps(va_range!(0xfff..0x1001)));
-    /// assert!(range.overlaps(va_range!(0x1fff..0x2001)));
-    /// assert!(range.overlaps(va_range!(0xfff..0x2001)));
+    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+    /// assert!(!range.overlaps(VirtAddrRange::from(0xfff..0xfff)));
+    /// assert!(!range.overlaps(VirtAddrRange::from(0x2000..0x2000)));
+    /// assert!(!range.overlaps(VirtAddrRange::from(0xfff..0x1000)));
+    /// assert!(range.overlaps(VirtAddrRange::from(0xfff..0x1001)));
+    /// assert!(range.overlaps(VirtAddrRange::from(0x1fff..0x2001)));
+    /// assert!(range.overlaps(VirtAddrRange::from(0xfff..0x2001)));
     /// ```
     #[inline]
     pub fn overlaps(self, other: Self) -> bool {

--- a/src/range.rs
+++ b/src/range.rs
@@ -16,11 +16,11 @@ macro_rules! usize {
 /// # Example
 ///
 /// ```
-/// use memory_addr::{AddrRange, VirtAddr};
+/// use memory_addr::AddrRange;
 ///
-/// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
-/// assert_eq!(range.start, 0x1000.into());
-/// assert_eq!(range.end, 0x2000.into());
+/// let range = AddrRange::<usize>::new(0x1000, 0x2000);
+/// assert_eq!(range.start, 0x1000);
+/// assert_eq!(range.end, 0x2000);
 /// ```
 #[derive(Clone, Copy)]
 pub struct AddrRange<A: MemoryAddr> {

--- a/src/range.rs
+++ b/src/range.rs
@@ -223,11 +223,30 @@ where
 /// Implementations of [`fmt::Debug`] for [`AddrRange`].
 impl<A> fmt::Debug for AddrRange<A>
 where
-    A: MemoryAddr,
+    A: MemoryAddr + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // todo: maybe use <A as fmt::Debug>::fmt?
-        write!(f, "{:#x?}..{:#x?}", usize!(self.start), usize!(self.end))
+        write!(f, "{:?}..{:?}", self.start, self.end)
+    }
+}
+
+/// Implementations of [`fmt::LowerHex`] for [`AddrRange`].
+impl<A> fmt::LowerHex for AddrRange<A>
+where
+    A: MemoryAddr + fmt::LowerHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:x}..{:x}", self.start, self.end)
+    }
+}
+
+/// Implementations of [`fmt::UpperHex`] for [`AddrRange`].
+impl<A> fmt::UpperHex for AddrRange<A>
+where
+    A: MemoryAddr + fmt::UpperHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:X}..{:X}", self.start, self.end)
     }
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -16,9 +16,9 @@ macro_rules! usize {
 /// ## Example
 ///
 /// ```
-/// use memory_addr::VirtAddrRange;
+/// use memory_addr::{AddrRange, VirtAddr};
 ///
-/// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
+/// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
 /// assert_eq!(range.start, 0x1000.into());
 /// assert_eq!(range.end, 0x2000.into());
 /// ```

--- a/src/range.rs
+++ b/src/range.rs
@@ -13,7 +13,7 @@ macro_rules! usize {
 /// The range is inclusive on the start and exclusive on the end.
 /// It is empty if `start >= end`.
 ///
-/// ## Example
+/// # Example
 ///
 /// ```
 /// use memory_addr::{AddrRange, VirtAddr};

--- a/src/range.rs
+++ b/src/range.rs
@@ -220,7 +220,9 @@ where
     }
 }
 
+/// A range of virtual addresses.
 pub type VirtAddrRange = AddrRange<VirtAddr>;
+/// A range of physical addresses.
 pub type PhysAddrRange = AddrRange<PhysAddr>;
 
 /// Converts the given range expression into [`VirtAddrRange`].

--- a/src/range.rs
+++ b/src/range.rs
@@ -214,6 +214,7 @@ impl<A, T> From<Range<T>> for AddrRange<A>
 where
     A: MemoryAddr + From<T>,
 {
+    #[inline]
     fn from(range: Range<T>) -> Self {
         Self::new(range.start.into(), range.end.into())
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -40,11 +40,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
-    /// assert_eq!(range.start, 0x1000.into());
-    /// assert_eq!(range.end, 0x2000.into());
+    /// let range = AddrRange::new(0x1000usize, 0x2000);
+    /// assert_eq!(range.start, 0x1000);
+    /// assert_eq!(range.end, 0x2000);
     /// ```
     #[inline]
     pub const fn new(start: A, end: A) -> Self {
@@ -56,11 +56,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = AddrRange::<VirtAddr>::from_start_size(0x1000.into(), 0x1000);
-    /// assert_eq!(range.start, 0x1000.into());
-    /// assert_eq!(range.end, 0x2000.into());
+    /// let range = AddrRange::from_start_size(0x1000usize, 0x1000);
+    /// assert_eq!(range.start, 0x1000);
+    /// assert_eq!(range.end, 0x2000);
     /// ```
     #[inline]
     pub fn from_start_size(start: A, size: usize) -> Self {
@@ -75,11 +75,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
+    /// use memory_addr::AddrRange;
     ///
-    /// assert!(AddrRange::<VirtAddr>::from(0x1000..0x1000).is_empty());
-    /// assert!(AddrRange::<VirtAddr>::from(0x1000..0xfff).is_empty());
-    /// assert!(!AddrRange::<VirtAddr>::from(0x1000..0x2000).is_empty());
+    /// assert!(AddrRange::new(0x1000usize, 0x1000).is_empty());
+    /// assert!(AddrRange::new(0x1000usize, 0xfff).is_empty());
+    /// assert!(!AddrRange::new(0x1000usize, 0x2000).is_empty());
     /// ```
     #[inline]
     pub fn is_empty(self) -> bool {
@@ -91,10 +91,10 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
+    /// use memory_addr::AddrRange;
     ///
-    /// assert_eq!(AddrRange::<VirtAddr>::from(0x1000..0x1000).size(), 0);
-    /// assert_eq!(AddrRange::<VirtAddr>::from(0x1000..0x2000).size(), 0x1000);
+    /// assert_eq!(AddrRange::new(0x1000usize, 0x1000).size(), 0);
+    /// assert_eq!(AddrRange::new(0x1000usize, 0x2000).size(), 0x1000);
     /// ```
     #[inline]
     pub fn size(self) -> usize {
@@ -106,13 +106,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = AddrRange::<VirtAddr>::new(0x1000.into(), 0x2000.into());
-    /// assert!(!range.contains(0xfff.into()));
-    /// assert!(range.contains(0x1000.into()));
-    /// assert!(range.contains(0x1fff.into()));
-    /// assert!(!range.contains(0x2000.into()));
+    /// let range = AddrRange::new(0x1000usize, 0x2000);
+    /// assert!(!range.contains(0xfff));
+    /// assert!(range.contains(0x1000));
+    /// assert!(range.contains(0x1fff));
+    /// assert!(!range.contains(0x2000));
     /// ```
     #[inline]
     pub fn contains(self, addr: A) -> bool {
@@ -124,16 +124,15 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
-    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
-    /// assert!(!range.contains_range(VirtAddrRange::from(0x0..0xfff)));
-    /// assert!(!range.contains_range(VirtAddrRange::from(0xfff..0x1fff)));
-    /// assert!(range.contains_range(VirtAddrRange::from(0x1001..0x1fff)));
-    /// assert!(range.contains_range(VirtAddrRange::from(0x1000..0x2000)));
-    /// assert!(!range.contains_range(VirtAddrRange::from(0x1001..0x2001)));
-    /// assert!(!range.contains_range(VirtAddrRange::from(0x2001..0x3001)));
+    /// let range = AddrRange::new(0x1000usize, 0x2000);
+    /// assert!(!range.contains_range(AddrRange::from(0x0usize..0xfff)));
+    /// assert!(!range.contains_range(AddrRange::from(0xfffusize..0x1fff)));
+    /// assert!(range.contains_range(AddrRange::from(0x1001usize..0x1fff)));
+    /// assert!(range.contains_range(AddrRange::from(0x1000usize..0x2000)));
+    /// assert!(!range.contains_range(AddrRange::from(0x1001usize..0x2001)));
+    /// assert!(!range.contains_range(AddrRange::from(0x2001usize..0x3001)));
     /// ```
     #[inline]
     pub fn contains_range(self, other: Self) -> bool {
@@ -145,14 +144,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
-    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
-    /// assert!(!range.contained_in(VirtAddrRange::from(0xfff..0x1fff)));
-    /// assert!(!range.contained_in(VirtAddrRange::from(0x1001..0x2001)));
-    /// assert!(range.contained_in(VirtAddrRange::from(0xfff..0x2001)));
-    /// assert!(range.contained_in(VirtAddrRange::from(0x1000..0x2000)));
+    /// let range = AddrRange::new(0x1000usize, 0x2000);
+    /// assert!(!range.contained_in(AddrRange::from(0xfffusize..0x1fff)));
+    /// assert!(!range.contained_in(AddrRange::from(0x1001usize..0x2001)));
+    /// assert!(range.contained_in(AddrRange::from(0xfffusize..0x2001)));
+    /// assert!(range.contained_in(AddrRange::from(0x1000usize..0x2000)));
     /// ```
     #[inline]
     pub fn contained_in(self, other: Self) -> bool {
@@ -164,16 +162,15 @@ where
     /// # Example
     ///
     /// ```
-    /// use memory_addr::{AddrRange, VirtAddr};
-    /// type VirtAddrRange = AddrRange<VirtAddr>; // as in `memory_addr`
+    /// use memory_addr::AddrRange;
     ///
-    /// let range = VirtAddrRange::new(0x1000.into(), 0x2000.into());
-    /// assert!(!range.overlaps(VirtAddrRange::from(0xfff..0xfff)));
-    /// assert!(!range.overlaps(VirtAddrRange::from(0x2000..0x2000)));
-    /// assert!(!range.overlaps(VirtAddrRange::from(0xfff..0x1000)));
-    /// assert!(range.overlaps(VirtAddrRange::from(0xfff..0x1001)));
-    /// assert!(range.overlaps(VirtAddrRange::from(0x1fff..0x2001)));
-    /// assert!(range.overlaps(VirtAddrRange::from(0xfff..0x2001)));
+    /// let range = AddrRange::new(0x1000usize, 0x2000usize);
+    /// assert!(!range.overlaps(AddrRange::from(0xfffusize..0xfff)));
+    /// assert!(!range.overlaps(AddrRange::from(0x2000usize..0x2000)));
+    /// assert!(!range.overlaps(AddrRange::from(0xfffusize..0x1000)));
+    /// assert!(range.overlaps(AddrRange::from(0xfffusize..0x1001)));
+    /// assert!(range.overlaps(AddrRange::from(0x1fffusize..0x2001)));
+    /// assert!(range.overlaps(AddrRange::from(0xfffusize..0x2001)));
     /// ```
     #[inline]
     pub fn overlaps(self, other: Self) -> bool {


### PR DESCRIPTION
A new trait named `MemoryAddr` is introduced to represent all memory-address-like things.

A macro named `def_addr_type` is introduced to generate definitions of `PhysAddr` and `VirtAddr` automatically.