### PR TITLE
Fix: `MemorySet::find_free_area` does not respect lower limit

### DIFF
--- a/memory_set/src/set.rs
+++ b/memory_set/src/set.rs
@@ -71,6 +71,9 @@ impl<B: MappingBackend> MemorySet<B> {
     ) -> Option<B::Addr> {
         // brute force: try each area's end address as the start.
         let mut last_end = hint.max(limit.start);
+        if let Some((_, area)) = self.areas.range(..last_end).last() {
+            last_end = last_end.max(area.end());
+        }
         for (&addr, area) in self.areas.range(last_end..) {
             if last_end.checked_add(size).is_some_and(|end| end <= addr) {
                 return Some(last_end);

--- a/memory_set/src/set.rs
+++ b/memory_set/src/set.rs
@@ -71,7 +71,7 @@ impl<B: MappingBackend> MemorySet<B> {
     ) -> Option<B::Addr> {
         // brute force: try each area's end address as the start.
         let mut last_end = hint.max(limit.start);
-        for (&addr, area) in self.areas.iter() {
+        for (&addr, area) in self.areas.range(last_end..) {
             if last_end.checked_add(size).is_some_and(|end| end <= addr) {
                 return Some(last_end);
             }


### PR DESCRIPTION
The current implementation of `MemorySet::find_free_area` does not actually take `limit.start` & `hint` into consideration, since `last_end` would be re-assigned in the first iteration anyway.

This PR fixes this issue by limiting the iteration range. This is also more performant than the original version under most scenario.