### PR TITLE
[feat] support alignment for `find_free_area`

### DIFF
--- a/memory_set/src/tests.rs
+++ b/memory_set/src/tests.rs
@@ -341,24 +341,24 @@ fn test_find_free_area() {
         ));
     }
 
-    let addr = set.find_free_area(0.into(), 0x1000, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0.into(), 0x1000, va_range!(0..MAX_ADDR), 1);
     assert_eq!(addr, Some(0x1000.into()));
 
-    let addr = set.find_free_area(0x800.into(), 0x800, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0x800.into(), 0x800, va_range!(0..MAX_ADDR), 0x800);
     assert_eq!(addr, Some(0x1000.into()));
 
-    let addr = set.find_free_area(0x1800.into(), 0x800, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0x1800.into(), 0x800, va_range!(0..MAX_ADDR), 0x800);
     assert_eq!(addr, Some(0x1800.into()));
 
-    let addr = set.find_free_area(0x1800.into(), 0x1000, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0x1800.into(), 0x1000, va_range!(0..MAX_ADDR), 0x1000);
     assert_eq!(addr, Some(0x3000.into()));
 
-    let addr = set.find_free_area(0x2000.into(), 0x1000, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0x2000.into(), 0x1000, va_range!(0..MAX_ADDR), 0x1000);
     assert_eq!(addr, Some(0x3000.into()));
 
-    let addr = set.find_free_area(0xf000.into(), 0x1000, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0xf000.into(), 0x1000, va_range!(0..MAX_ADDR), 0x1000);
     assert_eq!(addr, Some(0xf000.into()));
 
-    let addr = set.find_free_area(0xf001.into(), 0x1000, va_range!(0..MAX_ADDR));
+    let addr = set.find_free_area(0xf001.into(), 0x1000, va_range!(0..MAX_ADDR), 0x1000);
     assert_eq!(addr, None);
 }


### PR DESCRIPTION
This PR aims to add an `align` option to `find_free_area` to support huge pages.

The original `find_free_area` does not ensure the alignment of the final found area, even if the start and size are aligned.