### PR TITLE
feat: add page iter for huge pages and dynamic sizes

### DIFF
--- a/memory_addr/src/lib.rs
+++ b/memory_addr/src/lib.rs
@@ -6,7 +6,7 @@ mod iter;
 mod range;
 
 pub use self::addr::{MemoryAddr, PhysAddr, VirtAddr};
-pub use self::iter::PageIter;
+pub use self::iter::{DynPageIter, PageIter};
 pub use self::range::{AddrRange, PhysAddrRange, VirtAddrRange};
 
 /// The size of a 4K page (4096 bytes).

--- a/memory_addr/src/lib.rs
+++ b/memory_addr/src/lib.rs
@@ -12,8 +12,20 @@ pub use self::range::{AddrRange, PhysAddrRange, VirtAddrRange};
 /// The size of a 4K page (4096 bytes).
 pub const PAGE_SIZE_4K: usize = 0x1000;
 
+/// The size of a 2M page (2097152 bytes).
+pub const PAGE_SIZE_2M: usize = 0x20_0000;
+
+/// The size of a 1G page (1073741824 bytes).
+pub const PAGE_SIZE_1G: usize = 0x4000_0000;
+
 /// A [`PageIter`] for 4K pages.
 pub type PageIter4K<A> = PageIter<PAGE_SIZE_4K, A>;
+
+/// A [`PageIter`] for 2M pages.
+pub type PageIter2M<A> = PageIter<PAGE_SIZE_2M, A>;
+
+/// A [`PageIter`] for 1G pages.
+pub type PageIter1G<A> = PageIter<PAGE_SIZE_1G, A>;
 
 /// Align address downwards.
 ///


### PR DESCRIPTION
This pull request adds support for iterating over memory pages with dynamic page sizes and introduces new constants and type aliases for common page sizes.

A part of the code is extracted from https://github.com/arceos-org/axmm_crates/pull/7.