### PR TITLE
fix(mm): respect backend page_size when splitting areas

### DIFF
--- a/memory_set/src/area.rs
+++ b/memory_set/src/area.rs
@@ -114,6 +114,11 @@ impl<B: MappingBackend> MemoryArea<B> {
         let old_size = self.size();
         let unmap_size = old_size - new_size;
 
+        let new_start = self.va_range.start.wrapping_add(unmap_size);
+        if !new_start.is_aligned(self.backend().page_size()) {
+            return Err(MappingError::InvalidParam);
+        }
+        
         if !self.backend.unmap(self.start(), unmap_size, page_table) {
             return Err(MappingError::BadState);
         }
@@ -143,6 +148,10 @@ impl<B: MappingBackend> MemoryArea<B> {
         // Safety: `new_size` is less than the current size, so it will never overflow.
         let unmap_start = self.start().wrapping_add(new_size);
 
+        if !unmap_start.is_aligned(self.backend().page_size()) {
+            return Err(MappingError::InvalidParam);
+        }
+
         if !self.backend.unmap(unmap_start, unmap_size, page_table) {
             return Err(MappingError::BadState);
         }
@@ -160,6 +169,12 @@ impl<B: MappingBackend> MemoryArea<B> {
     /// Returns `None` if the given position is not in the memory area, or one
     /// of the parts is empty after splitting.
     pub(crate) fn split(&mut self, pos: B::Addr) -> Option<Self> {
+        // Do not split on addresses that are not aligned to the backend's
+        // page size. This is important for backends that use large pages
+        // (e.g. 2MiB): such mappings cannot be split at arbitrary positions.
+        if !pos.is_aligned(self.backend().page_size()) {
+            return None;
+        }
         if self.start() < pos && pos < self.end() {
             let new_area = Self::new(
                 pos,

--- a/memory_set/src/backend.rs
+++ b/memory_set/src/backend.rs
@@ -15,6 +15,17 @@ pub trait MappingBackend: Clone {
     /// The page table type used in the memory area.
     type PageTable;
 
+    /// The page size (in bytes) used by this backend.
+    ///
+    /// This is mainly used by [`MemoryArea`](crate::MemoryArea) to avoid
+    /// splitting a mapping at positions that are not page-aligned for this
+    /// backend. By default, the value is `1`, which means "no additional
+    /// restriction" (any position is treated as aligned).
+    #[inline]
+    fn page_size(&self) -> usize {
+        1
+    }
+
     /// What to do when mapping a region within the area with the given flags.
     fn map(
         &self,


### PR DESCRIPTION
The backend page size should be considered.
For example,  we call a `sys_munmap` on a area mapped with `MAP_HUGETLB`, and assume we map into the address (0x20000 - 0x40000)  , and unmap the (0x20100 - 0x20200)  the `split`, `shrink_left` or the `shrink_right` will be called, finally the `unmap` in the `backend` will be called,  but we are not able to  `unmap` a portion of the area 