### PR TITLE
fix: respect backend page size when splitting or shrinking area

### DIFF
--- a/memory_set/src/backend.rs
+++ b/memory_set/src/backend.rs
@@ -35,4 +35,13 @@ pub trait MappingBackend: Clone {
         new_flags: Self::Flags,
         page_table: &mut Self::PageTable,
     ) -> bool;
+
+    /// Returns the granularity (in bytes) this backend expects mapping operations
+    /// (split/shrink/unmap/protect) to operate on.
+    ///
+    /// Defaults to 4KiB. Backends that manage huge-page mappings should override
+    /// this to return their huge page size to avoid unintended huge-page splits.
+    fn page_size(&self) -> usize {
+        memory_addr::PAGE_SIZE_4K
+    }
 }


### PR DESCRIPTION
 The original implementation could cause the area mmapped with `MAP_HUGETLB` or  `MAP_HUGE_1GB` splitted 
(`e.g`. the original va_range is [0x20000-0x40000), after splitting, the range becomes [0x20000-0x22000) [0x22000-0x40000).
 later, if `munmap(0x20000, PAGE_SIZE_2M)` is called, since the original area is splitted, both the `va_range` of the  two new areas splitted from the original area is not aligned, causing the system to crash when the `unmap_area` is called inside `MemorySet::unmap`